### PR TITLE
JS date object & formatted values supported

### DIFF
--- a/View/Helper/GChartHelper.php
+++ b/View/Helper/GChartHelper.php
@@ -94,9 +94,9 @@ class GChartHelper extends AppHelper {
 	});
 </script>
 		';
-		$o .= sprintf($drawTemplate, 
-			$this->loadDataAndLabels($data), 
-			$this->instantiateGraph($name, $data['type']), 
+		$o .= sprintf($drawTemplate,
+			$this->loadDataAndLabels($data),
+			$this->instantiateGraph($name, $data['type']),
 			$data['width'],
 			$data['height'],
 			$data['is3D'],
@@ -124,13 +124,25 @@ class GChartHelper extends AppHelper {
 		}
 		foreach ($data['data'] as $datum) {
 			$entry = array_map(function($entry) {
+				// The entry may have come in as an array...
+				//   if so, we just use it as is.
+				if (is_array($entry)) {
+					return $entry;
+				}
+				// The entry is a simple value, so we wrap it in [v=>...]
 				return array('v' => $entry);
 			}, $datum);
 			$formatted['rows'][] = array(
 				'c' => $entry
 			);
 		}
-		return json_encode($formatted);
+		$json = json_encode($formatted);
+		if (strpos($json, 'new Date') != false) {
+			// did we json_encode a JS Date creation?
+			//   remove quotes around the "new Date()" value
+			$json = preg_replace('#"(new Date\([0-9, ]+\))"#', '$1', $json);
+		}
+		return $json;
 	}
 
 	/**


### PR DESCRIPTION
- added the ability to specify a JS date object as data value
- added the ability to specify an array, so you can customize the data value 'v' and the formatted version 'f'

https://developers.google.com/chart/interactive/docs/reference

v [Optional] The cell value. The data type should match the column data type. If null, the whole object should be empty and have neither v nor f properties.

f [Optional] A string version of the v value, formatted for display. The values should match, so if you specify Date(2008, 0, 1) for v, you should specify "January 1, 2008" or some such string for this property. This value is not checked against the v value. The visualization will not use this value for calculation, only as a label for display. If omitted, a string version of v will be used.
